### PR TITLE
nfp: workflow: add a check to catch 32-bit build errors

### DIFF
--- a/.github/deps/compile_check.sh
+++ b/.github/deps/compile_check.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Please specify commit count."
+    exit 1
+fi
+
+readonly ncommits=$1
+readonly module=drivers/net/ethernet/netronome/nfp
+
+for commit in $(git log --oneline --no-color -$ncommits --reverse | cut -d ' ' -f 1); do
+    echo "============== Checking $commit ========================"
+    git checkout $commit
+
+    commit_message=$(git log --oneline -1 | cut -d ' ' -f 2)
+    if [ "${commit_message}" == "github-patches-check:" ]; then
+        echo " Self-check detected, skipping...."
+        continue
+    fi
+
+    echo "----------- Compile check ------------"
+    make -j"$(nproc)" M="$module" clean
+
+    for i in 1 2; do
+        set +e
+        make -s -j"$(nproc)" EXTRA_CFLAGS+="-Werror -Wmaybe-uninitialized" \
+                M="$module" >& .build.log
+        ERROR="$?"
+        set -e
+        [ "$ERROR" != "0" ] || break
+        if [ "$i" != "1" ] || ! grep -q "ERROR: modpost: .* undefined" .build.log; then
+            cat .build.log
+            exit "$ERROR"
+        fi
+        # Rebuild entire kernel to refresh symbols
+        echo "--------------- Rebuild kernel -----------------"
+        make -s -j"$(nproc)"
+        echo "-------- Retry compile check ($target) ---------"
+    done
+done

--- a/.github/workflows/patch_chk.yaml
+++ b/.github/workflows/patch_chk.yaml
@@ -67,11 +67,17 @@ jobs:
         git clone --quiet --branch 1.72 --depth 1 git://repo.or.cz/smatch.git
         make -C ./smatch
 
-    - name: Configure & Build Kernel
+    - name: 64-bit Configure & Build Kernel
       run: |
         cp -p .github/deps/local_defconfig ./arch/x86/configs/
         make -s local_defconfig
         make -s -j"$(nproc)"
+
+    - name: Run compile check scripts for 64-bit
+      run: |
+        cp -p .github/deps/compile_check.sh ./
+        export PATH=$PATH:`pwd`/${{ env.UNPACKED }}/usr/bin
+        ./compile_check.sh ${{ steps.get-pr-info.outputs.commits }}
 
     - name: Run check scripts
       run: |
@@ -79,3 +85,15 @@ jobs:
         cp -p .github/deps/xmastree.py ./
         export PATH=$PATH:`pwd`/${{ env.UNPACKED }}/usr/bin
         ./commits_check.sh ${{ steps.get-pr-info.outputs.commits }}
+
+    - name: 32-bit Configure & Build Kernel
+      run: |
+        make -s clean -j"$(nproc)"
+        echo "# CONFIG_64BIT is not set" >> ./arch/x86/configs/local_defconfig
+        make -s local_defconfig
+        make -s -j"$(nproc)"
+
+    - name: Run compile check scripts for 32-bit
+      run: |
+        export PATH=$PATH:`pwd`/${{ env.UNPACKED }}/usr/bin
+        ./compile_check.sh ${{ steps.get-pr-info.outputs.commits }}

--- a/drivers/net/ethernet/netronome/nfp/flower/offload.c
+++ b/drivers/net/ethernet/netronome/nfp/flower/offload.c
@@ -1041,7 +1041,8 @@ int nfp_flower_merge_offloaded_flows(struct nfp_app *app,
 	if (!merge_flow)
 		return -ENOMEM;
 
-	merge_flow->tc_flower_cookie = (unsigned long)merge_flow;
+	//merge_flow->tc_flower_cookie = (unsigned long)merge_flow;
+	merge_flow->tc_flower_cookie = (u64)merge_flow;
 	merge_flow->ingress_dev = sub_flow1->ingress_dev;
 
 	memcpy(merge_flow->unmasked_data, sub_flow1->unmasked_data,


### PR DESCRIPTION
Avoid having work submitted upstream hit issue from 32-bit build
errors

Signed-off-by: Yu Xiao <yu.xiao@corigine.com>