### PR TITLE
github-patches-check: add a check to catch 32-bit build errors

### DIFF
--- a/.github/deps/commits_check.sh
+++ b/.github/deps/commits_check.sh
@@ -22,6 +22,7 @@ if [ -z "$1" ]; then
 fi
 
 readonly ncommits=$1
+readonly btype=${2:-64}
 
 exp_ccount=1
 exp_scount=0
@@ -71,6 +72,10 @@ for commit in $(git log --oneline --no-color -$ncommits --reverse | cut -d ' ' -
         make -s -j"$(nproc)"
         echo "-------- Retry compile check ($target) ---------"
     done
+
+    if [ "$btype" == "32" ]; then
+        continue
+    fi
 
     echo "----------- Checkpatch ---------------"
     if ! ./scripts/checkpatch.pl --strict -g $commit --ignore FILE_PATH_CHANGES; then

--- a/.github/deps/commits_check.sh
+++ b/.github/deps/commits_check.sh
@@ -36,10 +36,6 @@ module=drivers/net/ethernet/netronome/nfp
 # tree if a commit in the range will trigger this checkpatch.pl check.
 #
 # NOTE: This is an expensive operation and should only be trigger if needed.
-if grep -qiP "^fixes:|\bcommit\s+[0-9a-f]{6,40}\b" <<< $(git log -$ncommits --pretty=%B HEAD); then
-    echo "Check of commit(s) will requier access to the full git tree, fetch the full tree"
-    git fetch --quiet --unshallow
-fi
 
 for commit in $(git log --oneline --no-color -$ncommits --reverse | cut -d ' ' -f 1); do
     echo "============== Checking $commit ========================"

--- a/.github/workflows/patch_chk.yaml
+++ b/.github/workflows/patch_chk.yaml
@@ -67,7 +67,7 @@ jobs:
         git clone --quiet --branch 1.72 --depth 1 git://repo.or.cz/smatch.git
         make -C ./smatch
 
-    - name: Configure & Build Kernel
+    - name: 64-bit Configure & Build Kernel
       run: |
         cp -p .github/deps/local_defconfig ./arch/x86/configs/
         make -s local_defconfig
@@ -79,3 +79,15 @@ jobs:
         cp -p .github/deps/xmastree.py ./
         export PATH=$PATH:`pwd`/${{ env.UNPACKED }}/usr/bin
         ./commits_check.sh ${{ steps.get-pr-info.outputs.commits }}
+
+    - name: 32-bit Configure & Build Kernel
+      run: |
+        make -s clean -j"$(nproc)"
+        echo "# CONFIG_64BIT is not set" >> ./arch/x86/configs/local_defconfig
+        make -s local_defconfig
+        make -s -j"$(nproc)"
+
+    - name: Run check scripts
+      run: |
+        export PATH=$PATH:`pwd`/${{ env.UNPACKED }}/usr/bin
+        ./commits_check.sh ${{ steps.get-pr-info.outputs.commits }} 32


### PR DESCRIPTION
Avoid having work submitted upstream hit issue from 32-bit build
errors.

Signed-off-by: Yu Xiao <yu.xiao@corigine.com>